### PR TITLE
Add metadata for larger models and memory guard

### DIFF
--- a/IntPerInt/ModelManager.swift
+++ b/IntPerInt/ModelManager.swift
@@ -241,8 +241,20 @@ public class ModelManager: ObservableObject {
     func setCurrentModelForSelectedConversation(name: String) {
         guard let id = selectedConversationID,
               let idx = conversations.firstIndex(where: { $0.id == id }) else { return }
-    conversations[idx].model = name
-    // ロードは sendMessage 内で遅延実行
+        if let required = requiredMemoryGB(for: name) {
+            let totalGB = ProcessInfo.processInfo.physicalMemory / (1024 * 1024 * 1024)
+            if totalGB < UInt64(required) {
+                let msg = "メモリ不足: このモデルには \(required)GB 以上のRAMが推奨されます (現在: \(totalGB)GB)"
+                postSystemNotification(key: "insufficient_memory_\(name)", message: msg, severity: .error)
+                return
+            }
+        }
+        conversations[idx].model = name
+        // ロードは sendMessage 内で遅延実行
+    }
+
+    private func requiredMemoryGB(for fileName: String) -> Int? {
+        ModelInfo.availableModels.first(where: { $0.fileName == fileName })?.recommendedMemoryGB
     }
 
     private func syncMessagesIntoSelectedConversation() {
@@ -278,6 +290,20 @@ public class ModelManager: ObservableObject {
         
         if fileExists {
             if currentModelPath?.path != candidate.path {
+                if let required = requiredMemoryGB(for: modelName) {
+                    let totalGB = ProcessInfo.processInfo.physicalMemory / (1024 * 1024 * 1024)
+                    if totalGB < UInt64(required) {
+                        let pretty = self.prettyName(for: modelName)
+                        let msg = "メモリ不足のためモデルをロードできません: \(pretty)"
+                        logger.error("Insufficient memory for model \(modelName, privacy: .public)")
+                        await MainActor.run {
+                            self.engineStatus = .failed(message: msg)
+                            self.postSystemNotification(key: "insufficient_memory_\(modelName)", message: msg, severity: .error)
+                        }
+                        let err = NSError(domain: "ModelManager", code: 413, userInfo: [NSLocalizedDescriptionKey: msg])
+                        throw err
+                    }
+                }
                 await MainActor.run { self.engineStatus = .loading(modelName: modelName) }
                 // libエンジンのロードを非同期バックグラウンドで実行（メインスレッドをブロックしない）
                 do {
@@ -286,7 +312,7 @@ public class ModelManager: ObservableObject {
                         try lib.load(modelPath: candidate)
                         return lib
                     }.value
-                    
+
                     // メインアクターで状態更新
                     self.engine = loadedEngine
                     self.currentModelPath = candidate

--- a/IntPerInt/Models.swift
+++ b/IntPerInt/Models.swift
@@ -64,9 +64,32 @@ public struct ModelInfo: Identifiable, Hashable {
     let name: String
     let huggingFaceRepo: String
     let fileName: String
-    
-    // モデルカタログは無効化 - 手動でGGUFファイルを配置してください
-    static let availableModels: [ModelInfo] = []
+    let quantization: String
+    let recommendedMemoryGB: Int
+
+    static let availableModels: [ModelInfo] = [
+        ModelInfo(
+            name: "GPT-OSS 20B",
+            huggingFaceRepo: "gpt-oss/gpt-oss-20b-gguf",
+            fileName: "gpt-oss-20b-q4_0.gguf",
+            quantization: "q4_0",
+            recommendedMemoryGB: 24
+        ),
+        ModelInfo(
+            name: "DeepSeek LLM 67B",
+            huggingFaceRepo: "deepseek-ai/deepseek-llm-67b-gguf",
+            fileName: "deepseek-llm-67b-q4_k_m.gguf",
+            quantization: "q4_k_m",
+            recommendedMemoryGB: 64
+        ),
+        ModelInfo(
+            name: "GPT-OSS 120B (Experimental)",
+            huggingFaceRepo: "gpt-oss/gpt-oss-120b-gguf",
+            fileName: "gpt-oss-120b-q4_k_s.gguf",
+            quantization: "q4_k_s",
+            recommendedMemoryGB: 128
+        )
+    ]
 }
 // ※ 下部に重複/未完了だった ChatMessage 宣言を削除済み
 // (EOF)


### PR DESCRIPTION
## Summary
- expand model catalog with GPT-OSS 20B, DeepSeek LLM 67B, and experimental GPT-OSS 120B including quantization and memory recommendations
- guard model selection and loading with RAM checks to prevent impossible loads

## Testing
- `swiftc -typecheck IntPerInt/Models.swift IntPerInt/ModelManager.swift` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_68ac05e4687083298cbe3b0e8549f2b9